### PR TITLE
habitatctl: pass in env and flag vars from habitatctl client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 bin
 procs/*
 !procs/apps.yml
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ bin
 procs/*
 !procs/apps.yml
 .DS_Store
+data/

--- a/apps/ipfs/ipfs
+++ b/apps/ipfs/ipfs
@@ -1,13 +1,15 @@
 #!/bin/bash
 
-export IPFS_PATH=$DATA_DIR
-
-if [ ! -f "$IPFS_PATH" ]; then
+if [ ! -d "$IPFS_PATH" ]; then
+    mkdir -p $IPFS_PATH
+    echo "WARNING: this is not the standard way to initialize a private ipfs network"
+    echo "WARNING: use this for testing purposes only"
     a="initializing IPFS in "
     echo $a$IPFS_PATH
-    ipfs init
+    IPFS_PATH=$IPFS_PATH ipfs init
 else 
     echo "ipfs already initialized"
 fi
 
-ipfs daemon
+sleep 2
+IPFS_PATH=$IPFS_PATH ipfs daemon

--- a/cmd/habitat/main.go
+++ b/cmd/habitat/main.go
@@ -141,18 +141,18 @@ func decodeRequest(buf []byte) (*ctl.Request, error) {
 func requestRouter(req *ctl.Request) (*ctl.Response, error) {
 	switch req.Command {
 	case ctl.CommandStart:
-		err := ProcessManager.StartProcess(req)
+		err, procName := ProcessManager.StartProcess(req)
 		if err != nil {
 			return &ctl.Response{
 				Status:  ctl.StatusInternalServerError,
 				Message: err.Error(),
 			}, nil
 		}
-		fmt.Println(ProcessManager.Procs)
+		fmt.Println("Processes running: ", ProcessManager.Procs)
 
 		return &ctl.Response{
 			Status:  ctl.StatusOK,
-			Message: fmt.Sprintf("started process %s", req.Args),
+			Message: fmt.Sprintf("started process %s", procName),
 		}, nil
 	case ctl.CommandStop:
 		if len(req.Args) != 1 {
@@ -166,7 +166,7 @@ func requestRouter(req *ctl.Request) (*ctl.Response, error) {
 				Message: err.Error(),
 			}, nil
 		}
-		fmt.Println(ProcessManager.Procs)
+		fmt.Println("Processes running: ", ProcessManager.Procs)
 
 		return &ctl.Response{
 			Status:  ctl.StatusOK,

--- a/cmd/habitat/main.go
+++ b/cmd/habitat/main.go
@@ -141,10 +141,6 @@ func decodeRequest(buf []byte) (*ctl.Request, error) {
 func requestRouter(req *ctl.Request) (*ctl.Response, error) {
 	switch req.Command {
 	case ctl.CommandStart:
-		if len(req.Args) != 1 {
-			return nil, fmt.Errorf("start has %d arguments, expected 1", len(req.Args))
-		}
-
 		err := ProcessManager.StartProcess(req)
 		if err != nil {
 			return &ctl.Response{
@@ -156,7 +152,7 @@ func requestRouter(req *ctl.Request) (*ctl.Response, error) {
 
 		return &ctl.Response{
 			Status:  ctl.StatusOK,
-			Message: fmt.Sprintf("started process %s", req.Args[0]),
+			Message: fmt.Sprintf("started process %s", req.Args),
 		}, nil
 	case ctl.CommandStop:
 		if len(req.Args) != 1 {

--- a/cmd/habitat/main.go
+++ b/cmd/habitat/main.go
@@ -145,7 +145,7 @@ func requestRouter(req *ctl.Request) (*ctl.Response, error) {
 			return nil, fmt.Errorf("start has %d arguments, expected 1", len(req.Args))
 		}
 
-		err := ProcessManager.StartProcess(req.Args[0])
+		err := ProcessManager.StartProcess(req)
 		if err != nil {
 			return &ctl.Response{
 				Status:  ctl.StatusInternalServerError,

--- a/cmd/habitat/procs/manager.go
+++ b/cmd/habitat/procs/manager.go
@@ -60,7 +60,7 @@ func (m *Manager) StartProcess(req *ctl.Request) error {
 
 	cmdPath := filepath.Join(m.ProcDir, "bin", m.archOS, appConfig.Bin)
 	dataPath := filepath.Join(m.ProcDir, "data", subName)
-	proc := NewProc(subName, cmdPath, dataPath, m.errChan, req.Env, req.Flags)
+	proc := NewProc(subName, cmdPath, dataPath, m.errChan, req.Env, req.Flags, req.Args[1:])
 	err := proc.Start()
 	if err != nil {
 		return err

--- a/cmd/habitat/procs/manager.go
+++ b/cmd/habitat/procs/manager.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"sync"
 
 	"github.com/eagraf/habitat/cmd/habitat/proxy"
@@ -41,15 +42,11 @@ func NewManager(procDir string, rules proxy.RuleSet, appConfigs *configuration.A
 func (m *Manager) StartProcess(req *ctl.Request) error {
 	m.lock.Lock()
 	defer m.lock.Unlock()
-	fmt.Println("starting process")
-	fmt.Println(req.Command)
-	fmt.Println(req.Args)
-	fmt.Println(req.Env)
-	fmt.Println(req.Flags)
+	fmt.Printf("starting process %s \n", strings.Join(req.Args, " "))
 	name := req.Args[0]
 	subName := name
 	if len(req.Args) > 1 {
-		subName = name + "-" + req.Args[1]
+		subName = strings.Join(req.Args, "-")
 	}
 	fmt.Println("subname is", subName)
 	appConfig, ok := m.AppConfigs.Apps[name]

--- a/cmd/habitat/procs/manager.go
+++ b/cmd/habitat/procs/manager.go
@@ -48,7 +48,7 @@ func (m *Manager) StartProcess(req *ctl.Request) error {
 	if len(req.Args) > 1 {
 		subName = strings.Join(req.Args, "-")
 	}
-	fmt.Println("subname is", subName)
+
 	appConfig, ok := m.AppConfigs.Apps[name]
 	if !ok {
 		return fmt.Errorf("no app with name %s in app configurations", name)

--- a/cmd/habitat/procs/manager.go
+++ b/cmd/habitat/procs/manager.go
@@ -39,23 +39,24 @@ func NewManager(procDir string, rules proxy.RuleSet, appConfigs *configuration.A
 	}
 }
 
-func (m *Manager) StartProcess(req *ctl.Request) error {
+func (m *Manager) StartProcess(req *ctl.Request) (error, string) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
-	fmt.Printf("starting process %s \n", strings.Join(req.Args, " "))
+
 	name := req.Args[0]
 	subName := name
 	if len(req.Args) > 1 {
 		subName = strings.Join(req.Args, "-")
 	}
 
+	fmt.Printf("starting process %s \n", subName)
 	appConfig, ok := m.AppConfigs.Apps[name]
 	if !ok {
-		return fmt.Errorf("no app with name %s in app configurations", name)
+		return fmt.Errorf("no app with name %s in app configurations", name), ""
 	}
 
 	if _, ok := m.Procs[subName]; ok {
-		return fmt.Errorf("process with name %s already exists", subName)
+		return fmt.Errorf("process with name %s already exists", subName), ""
 	}
 
 	cmdPath := filepath.Join(m.ProcDir, "bin", m.archOS, appConfig.Bin)
@@ -63,35 +64,37 @@ func (m *Manager) StartProcess(req *ctl.Request) error {
 	proc := NewProc(subName, cmdPath, dataPath, m.errChan, req.Env, req.Flags, req.Args[1:])
 	err := proc.Start()
 	if err != nil {
-		return err
+		return err, ""
 	}
 
 	// Update reverse proxy ruleset
 	for _, ruleConfig := range appConfig.ProxyRules {
 		rule, err := proxy.GetRuleFromConfig(ruleConfig, m.ProcDir)
 		if err != nil {
-			return err
+			return err, ""
 		}
 		m.ProxyRules.Add(ruleConfig.Hash(), rule)
 	}
 
 	m.Procs[subName] = proc
-	return nil
+	return nil, subName
 }
 
-func (m *Manager) StopProcess(name string) error {
+func (m *Manager) StopProcess(subName string) error {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 
-	if _, ok := m.Procs[name]; !ok {
-		return fmt.Errorf("process with name %s does not exist", name)
+	fmt.Printf("stopping process %s \n", subName)
+	if _, ok := m.Procs[subName]; !ok {
+		return fmt.Errorf("process with name %s does not exist", subName)
 	}
-	err := m.Procs[name].Stop()
+	err := m.Procs[subName].Stop()
 	if err != nil {
 		return err
 	}
-	delete(m.Procs, name)
+	delete(m.Procs, subName)
 
+	name := strings.Split(subName, "-")[0]
 	appConfig, ok := m.AppConfigs.Apps[name]
 	if !ok {
 		return fmt.Errorf("no app with name %s in app configurations", name)

--- a/cmd/habitat/procs/manager.go
+++ b/cmd/habitat/procs/manager.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/eagraf/habitat/cmd/habitat/proxy"
 	"github.com/eagraf/habitat/structs/configuration"
+	"github.com/eagraf/habitat/structs/ctl"
 	"github.com/rs/zerolog/log"
 )
 
@@ -37,10 +38,11 @@ func NewManager(procDir string, rules proxy.RuleSet, appConfigs *configuration.A
 	}
 }
 
-func (m *Manager) StartProcess(name string) error {
+func (m *Manager) StartProcess(req *ctl.Request) error {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 
+	name := req.Args[0]
 	appConfig, ok := m.AppConfigs.Apps[name]
 	if !ok {
 		return fmt.Errorf("no app with name %s in app configurations", name)
@@ -52,7 +54,7 @@ func (m *Manager) StartProcess(name string) error {
 
 	cmdPath := filepath.Join(m.ProcDir, "bin", m.archOS, appConfig.Bin)
 	dataPath := filepath.Join(m.ProcDir, "data", name)
-	proc := NewProc(name, cmdPath, dataPath, m.errChan)
+	proc := NewProc(name, cmdPath, dataPath, m.errChan, req.Env, req.Flags)
 	err := proc.Start()
 	if err != nil {
 		return err

--- a/cmd/habitat/procs/proc.go
+++ b/cmd/habitat/procs/proc.go
@@ -2,7 +2,6 @@ package procs
 
 import (
 	"errors"
-	"fmt"
 	"os"
 	"os/exec"
 	"syscall"
@@ -42,8 +41,6 @@ func (p *Proc) Start() error {
 		Env:  p.Env,                                                      // require data dir to be passed in from client
 	}
 
-	fmt.Println("cmd env: ", cmd.Env)
-	fmt.Println("start cmd: ", cmd.String())
 	// start this process with a groupd id equal to its pid. this allows for all of its subprocesses to be killed
 	// at once by passing in the negative pid to syscall.Kill
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}

--- a/cmd/habitat/procs/proc.go
+++ b/cmd/habitat/procs/proc.go
@@ -2,6 +2,7 @@ package procs
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"syscall"
@@ -39,6 +40,8 @@ func (p *Proc) Start() error {
 		Env:  p.Env, // require data dir to be passed in from client
 	}
 
+	fmt.Println("cmd env: ", cmd.Env)
+	fmt.Println("start cmd: ", cmd.String())
 	// start this process with a groupd id equal to its pid. this allows for all of its subprocesses to be killed
 	// at once by passing in the negative pid to syscall.Kill
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}

--- a/cmd/habitat/procs/proc.go
+++ b/cmd/habitat/procs/proc.go
@@ -16,18 +16,20 @@ type Proc struct {
 	DataPath string
 	Env      []string
 	Flags    []string
+	Args     []string
 
 	cmd     *exec.Cmd
 	errChan chan ProcError
 }
 
-func NewProc(name, cmdPath, dataPath string, errChan chan ProcError, env []string, flags []string) *Proc {
+func NewProc(name, cmdPath, dataPath string, errChan chan ProcError, env []string, flags []string, args []string) *Proc {
 	return &Proc{
 		Name:     name,
 		CmdPath:  cmdPath,
 		DataPath: dataPath,
 		Env:      env,
 		Flags:    flags,
+		Args:     args,
 
 		errChan: errChan,
 	}
@@ -36,8 +38,8 @@ func NewProc(name, cmdPath, dataPath string, errChan chan ProcError, env []strin
 func (p *Proc) Start() error {
 	cmd := &exec.Cmd{
 		Path: p.CmdPath,
-		Args: append([]string{p.CmdPath}, p.Flags...),
-		Env:  p.Env, // require data dir to be passed in from client
+		Args: append(append([]string{p.CmdPath}, p.Args...), p.Flags...), // command [args] [flags]
+		Env:  p.Env,                                                      // require data dir to be passed in from client
 	}
 
 	fmt.Println("cmd env: ", cmd.Env)

--- a/cmd/habitat/procs/proc.go
+++ b/cmd/habitat/procs/proc.go
@@ -2,7 +2,6 @@ package procs
 
 import (
 	"errors"
-	"fmt"
 	"os"
 	"os/exec"
 	"syscall"
@@ -38,14 +37,7 @@ func (p *Proc) Start() error {
 		Path: p.CmdPath,
 		Args: append([]string{p.CmdPath}, p.Flags...),
 		Env:  p.Env, // require data dir to be passed in from client
-		/*
-			Env: []string{
-				fmt.Sprintf("DATA_DIR=%s", p.DataPath),
-			},
-		*/
 	}
-	fmt.Println("proc env: ", cmd.Env)
-	fmt.Println("start proc: ", cmd.String())
 
 	// start this process with a groupd id equal to its pid. this allows for all of its subprocesses to be killed
 	// at once by passing in the negative pid to syscall.Kill
@@ -75,7 +67,6 @@ func (p *Proc) Start() error {
 			}
 		}
 	}()
-
 	return nil
 }
 

--- a/cmd/habitatctl/commands/start.go
+++ b/cmd/habitatctl/commands/start.go
@@ -23,10 +23,9 @@ func parseFlags(args []string) ([]string, []string) {
 }
 
 var commName string
-var ipfsPath string
 
 var ipfsCmd = &cobra.Command{
-	Use:   "ipfs --comm=community_name --path=/path/to/ipfs/data -- -other -flags ENV_VAR=other_env_vars",
+	Use:   "ipfs --comm=community_name -- -other -flags ENV_VAR=other_env_vars",
 	Short: "Starts a habitat process",
 	Long:  `TODO create long description`,
 	Args:  cobra.MinimumNArgs(0),
@@ -43,7 +42,7 @@ var ipfsCmd = &cobra.Command{
 			Command: "start",
 			Args:    []string{"ipfs", commName},
 			Flags:   flags,
-			Env:     append(nonflags, fmt.Sprintf("IPFS_PATH=%s", ipfsPath)),
+			Env:     append(nonflags),
 		})
 
 		res, err := client.ReadResponse()
@@ -91,9 +90,6 @@ var startCmd = &cobra.Command{
 func init() {
 	startCmd.PersistentFlags().StringVarP(&commName, "comm", "c", "", "name of community for which to start process")
 	startCmd.MarkPersistentFlagRequired("comm")
-	ipfsCmd.Flags().StringVarP(&ipfsPath, "path", "p", "", "path to ipfs folder")
-	ipfsCmd.MarkFlagRequired("ipfs")
-	ipfsCmd.MarkFlagDirname("ipfs")
 	startCmd.AddCommand(ipfsCmd)
 	rootCmd.AddCommand(startCmd)
 

--- a/cmd/habitatctl/commands/start.go
+++ b/cmd/habitatctl/commands/start.go
@@ -2,28 +2,54 @@ package commands
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/eagraf/habitat/cmd/habitatctl/client"
 	"github.com/eagraf/habitat/structs/ctl"
 	"github.com/spf13/cobra"
 )
 
+func parseFlags(args []string) ([]string, []string) {
+	nonflags := []string{}
+	flags := []string{}
+	for _, arg := range args {
+		if strings.HasPrefix(arg, "--") || strings.HasPrefix(arg, "-") {
+			flags = append(flags, arg)
+		} else {
+			nonflags = append(nonflags, arg)
+		}
+	}
+	return flags, nonflags
+}
+
 // startCmd represents the start command
 var startCmd = &cobra.Command{
-	Use:   "start [process]",
+	Use:   "start [process] -- [env vars] [flags]",
 	Short: "Starts a habitat process",
 	Long:  `TODO create long description`,
-	Args:  cobra.ExactArgs(1),
+	Args:  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		process := args[0]
+		fmt.Println("start process ", process)
+		if cmd.ArgsLenAtDash() != 1 && cmd.ArgsLenAtDash() != -1 {
+			fmt.Println("Error: only one process should be specified before -- number specified: ", cmd.ArgsLenAtDash())
+			return
+		}
 		client, err := client.NewClient()
 		if err != nil {
 			fmt.Println("Error: couldn't connect to habitat service")
 			return
 		}
 
+		flags, nonflags := parseFlags(args[1:])
+		fmt.Println("flags ", flags)
+		fmt.Println("non flags", nonflags)
+
 		client.WriteRequest(&ctl.Request{
 			Command: "start",
-			Args:    args,
+			Args:    []string{args[0]},
+			Flags:   flags,
+			Env:     nonflags,
 		})
 
 		res, err := client.ReadResponse()

--- a/cmd/habitatctl/commands/start.go
+++ b/cmd/habitatctl/commands/start.go
@@ -22,10 +22,11 @@ func parseFlags(args []string) ([]string, []string) {
 	return flags, nonflags
 }
 
-var procName string
+var commName string
+var ipfsPath string
 
 var ipfsCmd = &cobra.Command{
-	Use:   "ipfs --name=network_name -- DATA_DIR=/path/to/data IPFS_PATH=/path/to/ipfs/data",
+	Use:   "ipfs --comm=community_name --path=/path/to/ipfs/data -- -other -flags ENV_VAR=other_env_vars",
 	Short: "Starts a habitat process",
 	Long:  `TODO create long description`,
 	Args:  cobra.MinimumNArgs(0),
@@ -40,9 +41,9 @@ var ipfsCmd = &cobra.Command{
 
 		client.WriteRequest(&ctl.Request{
 			Command: "start",
-			Args:    []string{"ipfs", procName},
+			Args:    []string{"ipfs", commName},
 			Flags:   flags,
-			Env:     nonflags,
+			Env:     append(nonflags, fmt.Sprintf("IPFS_PATH=%s", ipfsPath)),
 		})
 
 		res, err := client.ReadResponse()
@@ -74,7 +75,7 @@ var startCmd = &cobra.Command{
 
 		client.WriteRequest(&ctl.Request{
 			Command: "start",
-			Args:    args,
+			Args:    append(args, commName),
 			Flags:   flags,
 			Env:     nonflags,
 		})
@@ -88,8 +89,11 @@ var startCmd = &cobra.Command{
 }
 
 func init() {
-	ipfsCmd.Flags().StringVarP(&procName, "name", "n", "", "name of process to start")
-	ipfsCmd.MarkFlagRequired("name")
+	startCmd.PersistentFlags().StringVarP(&commName, "comm", "c", "", "name of community for which to start process")
+	startCmd.MarkPersistentFlagRequired("comm")
+	ipfsCmd.Flags().StringVarP(&ipfsPath, "path", "p", "", "path to ipfs folder")
+	ipfsCmd.MarkFlagRequired("ipfs")
+	ipfsCmd.MarkFlagDirname("ipfs")
 	startCmd.AddCommand(ipfsCmd)
 	rootCmd.AddCommand(startCmd)
 

--- a/go.mod
+++ b/go.mod
@@ -10,5 +10,5 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.8.1
 	github.com/stretchr/testify v1.7.0
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 )

--- a/structs/ctl/message.go
+++ b/structs/ctl/message.go
@@ -18,6 +18,8 @@ const (
 type Request struct {
 	Command string   `json:"command"`
 	Args    []string `json:"args"`
+	Env     []string `json:"env"`
+	Flags   []string `json:"flags"`
 }
 
 type Response struct {


### PR DESCRIPTION
when we start a process through habitat, we should be able to pass in flags and env vars for starting that process. we want to pass these in all the way from the client, that way apps can call habitatctl with other args

- works with ipfs 
- needs to be tested with notes / notes-backend 